### PR TITLE
Adds logical to valid the expired datetime param

### DIFF
--- a/nextcloud_async/api/ocs/shares.py
+++ b/nextcloud_async/api/ocs/shares.py
@@ -150,14 +150,17 @@ class OCSShareAPI(object):
             # TODO : fill me in
 
         """
-        # try:
-        #     expire_dt = dt.datetime.strptime(expire_date, r'%Y-%m-%d')
-        # except ValueError:
-        #     raise NextCloudException('Invalid date.  Should be YYYY-MM-DD')
-        # else:
-        #     now = dt.datetime.now()
-        #     if expire_dt < now:
-        #         raise NextCloudException('Invalid date.  Should be in the future.')
+
+        # Check exist the expired datetime param for evaluation, avoids this check if expired datatime param not exist
+        if expire_date:
+            try:
+                expire_dt = dt.datetime.strptime(expire_date, r'%Y-%m-%d')
+            except ValueError:
+                raise NextCloudException('Invalid date.  Should be YYYY-MM-DD')
+            else:
+                now = dt.datetime.now()
+                if expire_dt < now:
+                    raise NextCloudException('Invalid date.  Should be in the future.')
 
         return await self.ocs_query(
             method='POST',

--- a/nextcloud_async/api/ocs/shares.py
+++ b/nextcloud_async/api/ocs/shares.py
@@ -151,7 +151,7 @@ class OCSShareAPI(object):
 
         """
 
-        # Check exist the expired datetime param for evaluation, avoids this check if expired datatime param not exist
+        # Checks the expire_date argument exists before evaluation, otherwise continues.
         if expire_date:
             try:
                 expire_dt = dt.datetime.strptime(expire_date, r'%Y-%m-%d')


### PR DESCRIPTION
Adds a check that prevents the create_share raise an exception when no optional expire_date argument is given, in the api/ocs/shares.py module.